### PR TITLE
Update incoming header value type to String

### DIFF
--- a/src/tink/http/Container.hx
+++ b/src/tink/http/Container.hx
@@ -31,7 +31,7 @@ class NodeContainer implements Container {
       application.serve(
         new IncomingRequest(
           req.socket.remoteAddress, 
-          new IncomingRequestHeader(cast req.method, req.url, req.httpVersion, [for (name in req.headers.keys()) new HeaderField(name, req.headers[name])]), 
+          new IncomingRequestHeader(cast req.method, req.url, req.httpVersion, [for (name in req.headers.keys()) new HeaderField(name, (req.headers[name]: String))]), 
           Source.ofNodeStream(req, 'Incoming HTTP message from ${req.socket.remoteAddress}'))
       ).handle(function (out) {
         res.writeHead(out.header.statusCode, Std.string(out.header.statusCode), cast [for (h in out.header.fields) [(h.name : String), h.value]]);//TODO: readable status code


### PR DESCRIPTION
Fixes #5
I think it's safe to assume the header value will be String in this case, as there's only one exception according to the [nodejs docs](https://nodejs.org/api/http.html#http_message_headers) being `set-cookie` where it is an array.