### PR TITLE
Fix php tests

### DIFF
--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -81,11 +81,24 @@ class RunTests {
     #if php
     if (new Process('haxe', ['build-php.hxml']).exitCode() != 0)
       throw 'failed to build PHP';
-    var server = new Process('php', ['-S', '127.0.0.1:8000', 'testphp/index.php']);
+    var server = new Process('exec', ['php', '-S', '127.0.0.1:8000', 'testphp/index.php']);
+  var i = 0;
+  while (i < 20) {
+    try {
+      var socket = new sys.net.Socket();
+      socket.connect(new sys.net.Host('127.0.0.1'), 8000);
+      socket.close();
+      break;
+    } catch(e: Dynamic) {
+      Sys.sleep(.1);
+      i++;
+      continue;
+    }
+  }
     var done = f(new Host('127.0.0.1', 8000));
     ret.push(done);
     done.handle(function () {
-      server.kill();
+    server.kill();
     });
     #end 
 

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -82,23 +82,23 @@ class RunTests {
     if (new Process('haxe', ['build-php.hxml']).exitCode() != 0)
       throw 'failed to build PHP';
     var server = new Process('exec', ['php', '-S', '127.0.0.1:8000', 'testphp/index.php']);
-  var i = 0;
-  while (i < 20) {
-    try {
-      var socket = new sys.net.Socket();
-      socket.connect(new sys.net.Host('127.0.0.1'), 8000);
-      socket.close();
-      break;
-    } catch(e: Dynamic) {
-      Sys.sleep(.1);
-      i++;
-      continue;
+    var i = 0;
+    while (i < 20) {
+      try {
+        var socket = new sys.net.Socket();
+        socket.connect(new sys.net.Host('127.0.0.1'), 8000);
+        socket.close();
+        break;
+      } catch(e: Dynamic) {
+        Sys.sleep(.1);
+        i++;
+        continue;
+      }
     }
-  }
     var done = f(new Host('127.0.0.1', 8000));
     ret.push(done);
     done.handle(function () {
-    server.kill();
+      server.kill();
     });
     #end 
 

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -81,7 +81,7 @@ class RunTests {
     #if php
     if (new Process('haxe', ['build-php.hxml']).exitCode() != 0)
       throw 'failed to build PHP';
-    var server = new Process('exec', ['php', '-S', '127.0.0.1:8000', 'testphp/index.php']);
+    var server = new Process('php', ['-S', '127.0.0.1:8000', 'testphp/index.php']);
     var i = 0;
     while (i < 20) {
       try {


### PR DESCRIPTION
Waits for the php builtin server to accept connections and properly kills the process ([added exec](http://php.net/manual/en/function.proc-get-status.php#93382)).