### PR TITLE
Js container

### DIFF
--- a/src/tink/http/Client.hx
+++ b/src/tink/http/Client.hx
@@ -222,23 +222,15 @@ class LocalContainerClient implements ClientObject {
   }
   
   public function request(req:OutgoingRequest):Future<IncomingResponse> {
-    return switch container.server {
-      case null:
-        return Future.sync(new IncomingResponse(
-          new ResponseHeader(503, 'LocalContainer is not running', []),
-          tink.io.IdealSource.Empty.instance
-        ));
-      case server:
-        server.serve(new IncomingRequest(
-          '127.0.0.1',
-          new IncomingRequestHeader(req.header.method, req.header.uri, 'HTTP/1.1', req.header.fields),
-          Plain(req.body)
-        )) >>
-        function(res:OutgoingResponse) return new IncomingResponse(
-          res.header,
-          res.body
-        );
-      }
+      return container.serve(new IncomingRequest(
+        '127.0.0.1',
+        new IncomingRequestHeader(req.header.method, req.header.uri, 'HTTP/1.1', req.header.fields),
+        Plain(req.body)
+      )) >>
+      function(res:OutgoingResponse) return new IncomingResponse(
+        res.header,
+        res.body
+      );
     }
     
 }

--- a/src/tink/http/Client.hx
+++ b/src/tink/http/Client.hx
@@ -207,3 +207,26 @@ extern class NodeClient implements ClientObject {
   public function request(req:OutgoingRequest):Future<IncomingResponse>;
 }
 #end
+
+#if (js && !nodejs)
+class JsContainerClient implements ClientObject {
+  
+  var server:tink.http.containers.JsContainer.JsContainerServer;
+  public function new(server) {
+    this.server = server;
+  }
+  
+  public function request(req:OutgoingRequest):Future<IncomingResponse> {
+    return server.serve(new IncomingRequest(
+      '127.0.0.1',
+      new IncomingRequestHeader(req.header.method, req.header.uri, 'HTTP/1.1', req.header.fields),
+      Plain(req.body)
+    )) >>
+      function(res:OutgoingResponse) return new IncomingResponse(
+        res.header,
+        res.body
+      );
+  }
+  
+}
+#end

--- a/src/tink/http/Client.hx
+++ b/src/tink/http/Client.hx
@@ -235,7 +235,6 @@ class LocalContainerClient implements ClientObject {
     
 }
 #if (js && !nodejs)
-
 class JsSecureClient extends JsClient {
   override function request(req:OutgoingRequest):Future<IncomingResponse> {
     return jsRequest(req, switch req.header.host {

--- a/src/tink/http/containers/JsContainer.hx
+++ b/src/tink/http/containers/JsContainer.hx
@@ -1,0 +1,44 @@
+package tink.http.containers;
+
+import tink.http.Container;
+import tink.http.Request;
+import tink.http.Response;
+import tink.http.Header;
+import tink.io.IdealSource;
+
+using tink.CoreApi;
+
+class JsContainer implements Container {
+  public function new() {}
+  
+  public function run(handler:Handler) {
+    var running = true;
+    return Future.sync(Running(new JsContainerServer(handler)));
+  }
+}
+
+class JsContainerServer {
+  
+  public var failures(default, null):Signal<ContainerFailure>;
+  var running:Bool;
+  var handler:Handler;
+  
+  public function new(handler) {
+    this.handler = handler;
+    failures = new SignalTrigger();
+    running = true;
+  }
+  
+  public function serve(req:IncomingRequest) {
+    if(!running) return Future.sync(new OutgoingResponse(
+      new ResponseHeader(502, 'Gateway Error', []),
+      Empty.instance
+    ));
+    return handler.process(req);
+  }
+  
+  public function shutdown(hard:Bool) {
+    running = false;
+    return Future.sync(Noise);
+  }
+}

--- a/src/tink/http/containers/LocalContainer.hx
+++ b/src/tink/http/containers/LocalContainer.hx
@@ -8,20 +8,24 @@ import tink.io.IdealSource;
 
 using tink.CoreApi;
 
-class JsContainer implements Container {
+class LocalContainer implements Container {
+  
+  var server:LocalContainerServer;
+  
   public function new() {}
   
   public function run(handler:Handler) {
     var running = true;
-    return Future.sync(Running(new JsContainerServer(handler)));
+    server = new LocalContainerServer(handler);
+    return Future.sync(Running(server));
   }
 }
 
-class JsContainerServer {
+class LocalContainerServer {
   
   public var failures(default, null):Signal<ContainerFailure>;
-  var running:Bool;
   var handler:Handler;
+  var running:Bool;
   
   public function new(handler) {
     this.handler = handler;
@@ -31,7 +35,7 @@ class JsContainerServer {
   
   public function serve(req:IncomingRequest) {
     if(!running) return Future.sync(new OutgoingResponse(
-      new ResponseHeader(502, 'Gateway Error', []),
+      new ResponseHeader(503, 'Server stopped', []),
       Empty.instance
     ));
     return handler.process(req);

--- a/src/tink/http/containers/LocalContainer.hx
+++ b/src/tink/http/containers/LocalContainer.hx
@@ -10,7 +10,6 @@ using tink.CoreApi;
 
 class LocalContainer implements Container {
   
-  public var failures(default, null):Signal<ContainerFailure>;
   var handler:Handler;
   var running:Bool;
   


### PR DESCRIPTION
Borrowed the idea from ufront. 
A JsContainer is just a "server" that runs in the browser. It can be used to build isomorphic apps.

Usage example:
```haxe
static function main() {
	var container = new tink.http.containers.JsContainer();
	container.run(handler).handle(function(o) switch o {
		case Running(server):
			var client = new JsContainerClient(cast server);
			client.request(new OutgoingRequest(
				new OutgoingRequestHeader(GET, null, '/image.png'),
				''
			)).handle(function(res) {
				trace(res.header);
				res.body.all().handle(function(bytes) {
					// Update the page with the response
					var data = bytes.sure();
					var encoded = haxe.crypto.Base64.encode(data);
					var img = document.createImageElement();
					img.src = "data:image/png;base64," + encoded;
					document.body.appendChild(img);
				});
			});
		default: throw "error creating js container";
	});
}
```

Currently the way to accept a request a bit hacky, it requires a cast from the RunningState to get the `JsContainerServer`. But this piece of code should be enough demonstrate the idea.