### PR TITLE
Add curl client

### DIFF
--- a/src/tink/http/Client.hx
+++ b/src/tink/http/Client.hx
@@ -396,6 +396,8 @@ class CurlClient implements ClientObject {
     args.push('-X');
     args.push(req.header.method);
     
+    // TODO: http version
+    
     for(header in req.header.fields) {
       args.push('-H');
       args.push('${header.name}: ${header.value}');

--- a/src/tink/http/Client.hx
+++ b/src/tink/http/Client.hx
@@ -358,3 +358,63 @@ class JsClient implements ClientObject {
   }
 }
 #end
+
+class SecureCurlClient extends CurlClient {
+  public function new(?curl) {
+    super(curl);
+    protocol = 'https';
+  }
+}
+
+// Does not restrict to any platform as long as they can run the curl command somehow
+class CurlClient implements ClientObject {
+  var curl:Array<String>->?Source->Source;
+  var protocol:String = 'http';
+  public function new(?curl:Array<String>->?Source->Source) {
+    this.curl = 
+      if(curl != null) curl;
+      else {
+        #if (sys || nodejs)
+          function(args, ?data) {
+            if(data != null) {
+              args.push('--data-binary');
+              args.push('@-');
+            }
+            var process = #if sys new sys.io.Process #elseif nodejs js.node.ChildProcess.spawn #end ('curl', args);
+            if(data != null) {
+              var sink = #if sys Sink.ofOutput #else Sink.ofNodeStream #end ('stdin', process.stdin);
+              data.pipeTo(sink).handle(function(_) sink.close());
+            }
+            return #if sys Source.ofInput #else Source.ofNodeStream #end ('stdout', process.stdout);
+          }
+        #else
+          throw "curl function not supplied";
+        #end
+      }
+  }
+  public function request(req:OutgoingRequest):Future<IncomingResponse> {
+    var args = [];
+    
+    args.push('-is');
+    
+    args.push('-X');
+    args.push(req.header.method);
+    
+    for(header in req.header.fields) {
+      args.push('-H');
+      args.push('${header.name}: ${header.value}');
+    }
+    
+    args.push('$protocol:' + req.header.fullUri());
+    
+    return req.body.all() >> 
+      function(bytes:haxe.io.Bytes) {
+        return curl(args, bytes.length == 0 ? null : bytes).parse(ResponseHeader.parser()).map(function (o) return switch o {
+          case Success({ data: header, rest: body }):
+            new IncomingResponse(header, body);
+          case Failure(e):
+            new IncomingResponse(new ResponseHeader(e.code, e.message, []), (e.message : Source).append(e));
+        });
+      }
+  }
+}

--- a/src/tink/http/Client.hx
+++ b/src/tink/http/Client.hx
@@ -376,15 +376,11 @@ class CurlClient implements ClientObject {
       else {
         #if (sys || nodejs)
           function(args, body) {
-            if(body != null) {
-              args.push('--data-binary');
-              args.push('@-');
-            }
+            args.push('--data-binary');
+            args.push('@-');
             var process = #if sys new sys.io.Process #elseif nodejs js.node.ChildProcess.spawn #end ('curl', args);
-            if(body != null) {
-              var sink = #if sys Sink.ofOutput #else Sink.ofNodeStream #end ('stdin', process.stdin);
-              body.pipeTo(sink).handle(function(_) sink.close());
-            }
+            var sink = #if sys Sink.ofOutput #else Sink.ofNodeStream #end ('stdin', process.stdin);
+            body.pipeTo(sink).handle(function(_) sink.close());
             return #if sys Source.ofInput #else Source.ofNodeStream #end ('stdout', process.stdout);
           }
         #else

--- a/src/tink/http/Response.hx
+++ b/src/tink/http/Response.hx
@@ -37,8 +37,8 @@ class ResponseHeader extends Header {
   static public function parser():StreamParser<ResponseHeader>
     return new HeaderParser<ResponseHeader>(function (line, headers) 
       return switch line.split(' ') {
-        case [protocol, status, reason]:
-          Success(new ResponseHeader(Std.parseInt(status), reason, headers, protocol));
+        case v if(v.length >= 3):
+          Success(new ResponseHeader(Std.parseInt(v[1]), v.slice(2).join(' '), headers, v[0]));
         default: 
           Failure(new Error(UnprocessableEntity, 'Invalid HTTP response header'));
       }


### PR DESCRIPTION
This one is a bit exotic.

I am recently writing a mongo shell script to migrate data. In the process I need to fetch some external information from the web. The problem is that the mongo javascript shell environment doesn't seem to provide any means to connect to the web. However, I am able to run some shell commands there. So I can use curl to do my job.

In this CurlClient, one provides a `curl` function which would take the command line arguments for curl and body data (if any), run it with curl and return the raw response bytes as `Source`. Default implementation of such functions for the `sys || nodejs` targets is also there.