### PR TITLE
3.2.1 compatibility

### DIFF
--- a/src/tink/http/Client.hx
+++ b/src/tink/http/Client.hx
@@ -59,7 +59,7 @@ class StdClient implements ClientObject {
                 case null: [];
                 case v:
                   [for (name in v.keys()) 
-                    new HeaderField(name, v[name])
+                    new HeaderField(name, v.get(name))
                   ];
               }
             #else


### PR DESCRIPTION
Array access is not allowed on haxe.ds.StringMap<String>