### PR TITLE
fix fetch() on neko so it returns Failure(e) instead of throwing an exception

### DIFF
--- a/src/tink/http/clients/SocketClient.hx
+++ b/src/tink/http/clients/SocketClient.hx
@@ -58,9 +58,14 @@ class SocketClient implements ClientObject {
       }
       
       worker.work(function() {
-        socket.connect(new sys.net.Host(req.header.url.host.name), port);
-        return Noise;
-      }).handle(function(_) {
+        return try { socket.connect( new sys.net.Host(req.header.url.host.name), port); Success(Noise); }
+        catch (e:Dynamic) Failure(new Error(Std.string(e))); 
+      }).handle(function(outcome : Outcome<Noise, Error>) {
+        switch outcome { 
+            case Success(_):
+            case Failure(e): return cb(Failure(e));
+        }
+
         var sink = Sink.ofOutput('Request to ${req.header.url}', socket.output, {worker: worker});
         var source = Source.ofInput('Response from ${req.header.url}', socket.input, {worker: worker});
         


### PR DESCRIPTION
When using tink_http on a neko client and fetch()-ing some unreachable
server, you get an Exception from neko ("failed to connect to localhost:8080").

I think this is a bug. The exception is called from tink_http's SocketClient, this line:
`socket.connect( new sys.net.Host(req.header.url.host.name), port);`

So it's thrown by neko. This file has mostly been untouched since 2017, probably because of rare usage of neko amongst tinkers. 

Note for me the modifications proposed in the PR work (no more exception, Failure returned instead). Feel free to review and propose better code