### PR TITLE
[breaking] Rework aws

### DIFF
--- a/src/tink/http/containers/AwsLambdaNodeContainer.hx
+++ b/src/tink/http/containers/AwsLambdaNodeContainer.hx
@@ -7,6 +7,7 @@ import tink.http.Container;
 import tink.http.Request;
 import tink.http.Response;
 import tink.http.Header;
+import #if haxe4 js.lib.Error #else js.Error #end as JsError;
 
 using tink.io.Source;
 using tink.CoreApi;
@@ -40,7 +41,7 @@ class AwsLambdaNodeContainer implements Container {
     this.isBinary = isBinary == null ? function(_) return false : isBinary;
   }
   
-  inline function getRequest():IncomingRequest {
+  inline function getRequest(event:LambdaEvent):IncomingRequest {
     return new IncomingRequest(
       event.requestContext.sourceIp,
       new IncomingRequestHeader(
@@ -65,9 +66,9 @@ class AwsLambdaNodeContainer implements Container {
       Reflect.setField(
         js.Node.exports,
         name,
-        function(event:LambdaEvent, context:Dynamic, callback:js.Error->LambdaResponse->Void) {
+        function(event:LambdaEvent, context:Dynamic, callback:JsError->LambdaResponse->Void) {
           context.callbackWaitsForEmptyEventLoop = false;
-          handler.process(getRequest()).handle(function(res) {
+          handler.process(getRequest(event)).handle(function(res) {
             var binary = isBinary(res.header);
             res.body.all().handle(function(chunk) {
               var res:LambdaResponse = {

--- a/src/tink/http/containers/AwsLambdaNodeContainer.hx
+++ b/src/tink/http/containers/AwsLambdaNodeContainer.hx
@@ -25,7 +25,9 @@ using tink.CoreApi;
  *  ```
  *  class Server {
  *    static function main() {
- *      var container = new AwsLambdaNodeContainer('handler');
+ *      // handler function will be exposed as the name specified
+ *      // note that the container must be created synchronously in the main function
+ *      var container = new AwsLambdaNodeContainer('index'); 
  *      container.run(function(req) return Future.sync(('Done':OutgoingResponse))).eager();
  *    }
  *  }


### PR DESCRIPTION
Changed the way to use (no more manual `@:expose`) and more importantly fixed a few issues:

1. support duplicated headers and query params
2. fixed path construction to properly handle API path mapping

This is a breaking change but considering tink_http is not yet 1.0.0 so I will just go ahead and merge.