### PR TITLE
Avoid malformed URL when using `CurlClient` with an `Url` without protocol.

### DIFF
--- a/src/tink/http/clients/CurlClient.hx
+++ b/src/tink/http/clients/CurlClient.hx
@@ -38,7 +38,8 @@ class CurlClient implements ClientObject {
       args.push('${header.name}: ${header.value}');
     }
     
-    args.push(req.header.url);
+    var url = req.header.url;
+    args.push(url.scheme != null ? url : protocol + ':' + url);
     
     return curl(args, req.body)
       .parse(ResponseHeader.parser())


### PR DESCRIPTION
This enables me to use `CurlClient` with the JVM target using `tink_web`.

By the way, it looks like the `curl` command return code is not being taken into account... but I don't know enough of Tink internals to be confident about implementing some fix. In this case, adding `process.exitCode(true)` just before `CurlClient.curl` `return` statement allowed me to see the exit code being `3`, which means *URL malformed*... but I think that call is blocking, not sure if that would be a problem or if there is a better place to, say, throw exceptions or return failures if the return code isn't `0`.