### PR TITLE
Reenable explicit missing scheme error in JsClient

### DIFF
--- a/src/tink/http/clients/JsClient.hx
+++ b/src/tink/http/clients/JsClient.hx
@@ -11,7 +11,6 @@ import js.lib.Int8Array;
 #else
 import js.html.Int8Array;
 #end
-using StringTools;
 
 using tink.io.Source;
 using tink.CoreApi;

--- a/src/tink/http/clients/JsClient.hx
+++ b/src/tink/http/clients/JsClient.hx
@@ -25,7 +25,7 @@ class JsClient implements ClientObject {
   public function request(req:OutgoingRequest):Promise<IncomingResponse> {
     return Future.async(function(cb) {
       var http = getHttp();
-      // if(req.header.url.scheme == null) cb(Failure(Helper.missingSchemeError()));
+      if(req.header.url.scheme == null || req.header.url.scheme == "undefined") cb(Failure(Helpers.missingSchemeError()));
       http.open(req.header.method, req.header.url);
       http.withCredentials = credentials;
       http.responseType = ARRAYBUFFER;

--- a/src/tink/http/clients/JsClient.hx
+++ b/src/tink/http/clients/JsClient.hx
@@ -26,7 +26,7 @@ class JsClient implements ClientObject {
     return Future.async(function(cb) {
       var http = getHttp();
       // null scheme is for urls such as "//google.com/foo" where the scheme of current url is to be reused
-      if(req.header.url.scheme != null && !req.header.url.scheme != "http" !req.header.url.scheme != "https") cb(Failure(Helpers.missingSchemeError()));
+      if(req.header.url.scheme != null && req.header.url.scheme != "http" req.header.url.scheme != "https") cb(Failure(Helpers.missingSchemeError()));
       http.open(req.header.method, req.header.url);
       http.withCredentials = credentials;
       http.responseType = ARRAYBUFFER;

--- a/src/tink/http/clients/JsClient.hx
+++ b/src/tink/http/clients/JsClient.hx
@@ -11,6 +11,7 @@ import js.lib.Int8Array;
 #else
 import js.html.Int8Array;
 #end
+using StringTools;
 
 using tink.io.Source;
 using tink.CoreApi;
@@ -25,7 +26,8 @@ class JsClient implements ClientObject {
   public function request(req:OutgoingRequest):Promise<IncomingResponse> {
     return Future.async(function(cb) {
       var http = getHttp();
-      if(req.header.url.scheme == null || req.header.url.scheme == "undefined") cb(Failure(Helpers.missingSchemeError()));
+      // null scheme is for urls such as "//google.com/foo" where the scheme of current url is to be reused
+      if(req.header.url.scheme != null && !req.header.url.scheme != "http" !req.header.url.scheme != "https") cb(Failure(Helpers.missingSchemeError()));
       http.open(req.header.method, req.header.url);
       http.withCredentials = credentials;
       http.responseType = ARRAYBUFFER;

--- a/src/tink/http/clients/JsClient.hx
+++ b/src/tink/http/clients/JsClient.hx
@@ -26,7 +26,7 @@ class JsClient implements ClientObject {
     return Future.async(function(cb) {
       var http = getHttp();
       // null scheme is for urls such as "//google.com/foo" where the scheme of current url is to be reused
-      if(req.header.url.scheme != null && req.header.url.scheme != "http" req.header.url.scheme != "https") cb(Failure(Helpers.missingSchemeError()));
+      if(req.header.url.scheme != null && req.header.url.scheme != "http" && req.header.url.scheme != "https") cb(Failure(Helpers.missingSchemeError()));
       http.open(req.header.method, req.header.url);
       http.withCredentials = credentials;
       http.responseType = ARRAYBUFFER;


### PR DESCRIPTION
I suggest to reenable this explicit message already in Helpers (missing http/https). It was probably commented out because it was not working, but fixed it.

*As to the specifics, my app once compiled with the latest tink/coconut libs, has its API calls fail ("502 XMLHttpRequest Error"). Some console.log in JsClient revealed it was because of missing scheme (`undefined` instead of `http`). Not having the explicit message can be a loss of time for future developers, hence this PR.* 