### PR TITLE
Edit UploadedFile.read() to return Bytes

### DIFF
--- a/src/tink/http/StructuredBody.hx
+++ b/src/tink/http/StructuredBody.hx
@@ -20,7 +20,7 @@ abstract UploadedFile(UploadedFileBase) from UploadedFileBase to UploadedFileBas
       fileName: name,
       mimeType: type,
       size: data.length,
-      read: function():RealSource return data,
+      read: function() return data,
       saveTo: function(path:String) {
         var name = 'File sink $path';
         var dest:RealSink = 
@@ -48,10 +48,10 @@ typedef UploadedFileBase = {
   var size(default, null):Int;
   
   /**
-   *  Read the uploaded file as Source
-   *  @return RealSource
+   *  Return the contents of the file
+   *  @return Bytes
    */
-  function read():RealSource;
+  function read():Bytes;
   
   /**
    *  Save the uploaded file to the specified location


### PR DESCRIPTION
I spent a good two hours yesterday scrolling through Tinkerbell code trying to figure out how do I extract the `Bytes` of an `UploadedFile` without saving it or piping it to a `Sink`, which seems like an unnecessary overhead (for big files, for example). This pull request changes `UploadedFile.read()` to return `Bytes` instead of `RealSource` in order to circumvent this.

Since `RealSource` seems to have automatic conversion from `Bytes`, this change should have no effect on existing code.

On a side note, is there a reason for having `typedef UploadFileBase` and `abstract UploadedFile` instead of just `class UploadedFile` or something like that? 