### PR TITLE
Fix HTTP-date weekday typo (Wen -> Wed)

### DIFF
--- a/src/tink/http/Header.hx
+++ b/src/tink/http/Header.hx
@@ -187,7 +187,7 @@ abstract HeaderValue(String) from String to String {
   public static function basicAuth(username:String, password:String)
     return 'Basic ' + Base64.encode(Bytes.ofString('$username:$password')).toString();
 
-  static var DAYS = 'Sun,Mon,Tue,Wen,Thu,Fri,Sat'.split(',');
+  static var DAYS = 'Sun,Mon,Tue,Wed,Thu,Fri,Sat'.split(',');
   static var MONTHS = 'Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec'.split(',');
   @:from static public function ofDate(d:Date):HeaderValue
     return DateTools.format(d, DAYS[d.getDay()] + ", %d " + MONTHS[d.getMonth()] + " %Y %H:%M:%S GMT");

--- a/tests/TestHeader.hx
+++ b/tests/TestHeader.hx
@@ -174,4 +174,9 @@ class TestHeader {
 	@:variant('foo', 'bar', 'Basic Zm9vOmJhcg==')
 	public function basicAuth(username:String, password:String, output:String)
 		return assert(HeaderValue.basicAuth(username, password) == output);
+
+	// noon avoids the weekday shifting across timezones
+	@:variant(new Date(2009, 10, 25, 12, 0, 0), 'Wed, 25 Nov 2009')
+	public function ofDate(date:Date, expected:String)
+		return assert((HeaderValue.ofDate(date):String).substr(0, expected.length) == expected);
 }


### PR DESCRIPTION
`HeaderValue.ofDate` produced malformed HTTP-dates on Wednesdays because the `DAYS` lookup table contained `Wen` instead of the correct `Wed` day-name abbreviation (RFC 7231 §7.1.1.1).

Fixes the typo and adds a small test asserting the weekday abbreviation for a known Wednesday.

Made with [Cursor](https://cursor.com)