### PR TITLE
Fix extra blank line when serializing empty header

### DIFF
--- a/src/tink/http/Header.hx
+++ b/src/tink/http/Header.hx
@@ -140,7 +140,7 @@ class Header {
     inline function get_LINEBREAK() return '\r\n';
 
   public function toString()
-    return [for (f in fields) f.toString()].join(LINEBREAK) + LINEBREAK + LINEBREAK;
+    return [for (f in fields) f.toString() + LINEBREAK].join('') + LINEBREAK;
 
   inline function headerNotFound(name)
     return 'No $name header found';

--- a/tests/TestHeader.hx
+++ b/tests/TestHeader.hx
@@ -21,7 +21,7 @@ class TestHeader {
 	static public var credentials(default, null) = 'usr:pwd';
 	static public var auth(default, null) = HeaderValue.basicAuth(credentials.split(':')[0], credentials.split(':')[1]);
 	@:describe('Build Outgoing Request Header')
-	@:variant(GET, 'https://www.example.com', HTTP1_1, [], 'GET / HTTP/1.1\r\n\r\n\r\n')
+	@:variant(GET, 'https://www.example.com', HTTP1_1, [], 'GET / HTTP/1.1\r\n\r\n')
 	@:variant(GET, 'https://www.example.com', HTTP2, [new tink.http.Header.HeaderField('host', 'v')], 'GET / HTTP/2\r\nhost: v\r\n\r\n')
 	@:variant(GET, 'https://${TestHeader.credentials}@www.example.com', HTTP2, [], 'GET / HTTP/2\r\nauthorization: ${TestHeader.auth}\r\n\r\n')
 	@:variant(GET, 'https://www.example.com', HTTP2, [new tink.http.Header.HeaderField(AUTHORIZATION, TestHeader.auth)], 'GET / HTTP/2\r\nauthorization: ${TestHeader.auth}\r\n\r\n')
@@ -31,7 +31,7 @@ class TestHeader {
 	}
 	#end
 
-	@:variant(200, 'OK', HTTP1_1, [], 'HTTP/1.1 200 OK\r\n\r\n\r\n')
+	@:variant(200, 'OK', HTTP1_1, [], 'HTTP/1.1 200 OK\r\n\r\n')
 	@:variant(403, 'Forbidden', HTTP2, [new tink.http.Header.HeaderField('content-length', '0')], 'HTTP/2 403 Forbidden\r\ncontent-length: 0\r\n\r\n')
 	public function buildResponseHeader(code:Int, reason:String, version:Protocol, fields:Array<HeaderField>, str:String) {
 		var header = new ResponseHeader(code, reason, fields, version);


### PR DESCRIPTION
`Header.toString()` appended two `\r\n` after the (empty) field list, so a message with no header fields serialized with an extra blank line, e.g. `GET / HTTP/1.1\r\n\r\n\r\n`. Per RFC 7230 §3, the header section is terminated by a single empty line.

The field block is now built as `field + CRLF` per field followed by one terminating `CRLF`, producing `GET / HTTP/1.1\r\n\r\n` for empty headers while leaving messages that do have fields unchanged (they still end with a single blank line after the last field).

Updated the `TestHeader` variants that asserted the old triple-CRLF empty-header form.

Made with [Cursor](https://cursor.com)