### PR TITLE
Support chunk extensions in chunked decoder

### DIFF
--- a/src/tink/http/Chunked.hx
+++ b/src/tink/http/Chunked.hx
@@ -73,7 +73,16 @@ class ChunkedParser implements StreamParserObject<Chunk> {
 		return
 			if(chunkSize < 0) {
 				switch cursor.seek(LINEBREAK) {
-					case Some(v): remaining = chunkSize = Std.parseInt('0x$v');
+					case Some(v):
+						var size = v.toString();
+						switch size.indexOf(';') { // strip optional chunk extensions
+							case -1: // no extension
+							case i: size = size.substr(0, i);
+						}
+						switch Std.parseInt('0x${size.trim()}') {
+							case null: return Failed(new Error('Invalid chunk size'));
+							case parsed: remaining = chunkSize = parsed;
+						}
 					case None: // do nothing
 				}
 				Progressed;

--- a/tests/TestChunked.hx
+++ b/tests/TestChunked.hx
@@ -28,6 +28,8 @@ class TestChunked {
   @:variant('3\r\n123\r\n3\r\n123\r\n3\r\n123\r\n0\r\n\r\n', '123123123')
   @:variant('3\r\n123\r\n4\r\nA\r\nB\r\n3\r\n123\r\n0\r\n\r\n', '123A\r\nB123')
   @:variant('A\r\n1234567890\r\n0\r\n\r\n', '1234567890')
+  @:variant('3;foo=bar\r\n123\r\n0\r\n\r\n', '123') // chunk with extension
+  @:variant('3;a;b=c\r\n123\r\n0;done\r\n\r\n', '123') // multiple extensions, incl. on last chunk
   public function decode(input:IdealSource, output:String) {
     Chunked.decode(input).all()
       .next(decoded -> asserts.assert(decoded.toString() == output))


### PR DESCRIPTION
The chunked decoder parsed the whole chunk-size line as a hex number, so a valid chunk header carrying a chunk extension (e.g. `3;foo=bar`, RFC 7230 §4.1.1) was fed to `Std.parseInt` as `0x3;foo=bar` and failed to decode.

- Strip the optional chunk extension (everything from the first `;`) before parsing the hex size.
- Reject invalid/empty sizes with a parse error instead of silently producing a bad state.

Added `TestChunked` decode variants covering `3;foo=bar` and extensions on the terminating `0` chunk.

Made with [Cursor](https://cursor.com)