### PR TITLE
Prefer chunked Transfer-Encoding over Content-Length

### DIFF
--- a/src/tink/http/Request.hx
+++ b/src/tink/http/Request.hx
@@ -163,11 +163,17 @@ class IncomingRequest extends Message<IncomingRequestHeader, IncomingRequestBody
           parts.a,
           Plain(switch parts.a.getContentLength() {
             case Success(len):
-              parts.b.limit(len);
+              // RFC 7230 §3.3.3: a chunked Transfer-Encoding takes precedence over Content-Length
+              switch parts.a.byName(TRANSFER_ENCODING) {
+                case Success((_:String).toLowerCase().split(',').map(StringTools.trim) => encodings) if(encodings.indexOf('chunked') != -1):
+                  Chunked.decode(parts.b);
+                case _:
+                  parts.b.limit(len);
+              }
             case Failure(_):
               switch [parts.a.method, parts.a.byName(TRANSFER_ENCODING)] {
                 case [GET | OPTIONS, _]: Source.EMPTY;
-                case [_, Success((_:String).split(',').map(StringTools.trim) => encodings)] if(encodings.indexOf('chunked') != -1): Chunked.decode(parts.b);
+                case [_, Success((_:String).toLowerCase().split(',').map(StringTools.trim) => encodings)] if(encodings.indexOf('chunked') != -1): Chunked.decode(parts.b);
                 case _: return new Error(411, 'Content-Length header missing');
               }
           })

--- a/tests/TestHeader.hx
+++ b/tests/TestHeader.hx
@@ -179,4 +179,18 @@ class TestHeader {
 	@:variant(new Date(2009, 10, 25, 12, 0, 0), 'Wed, 25 Nov 2009')
 	public function ofDate(date:Date, expected:String)
 		return assert((HeaderValue.ofDate(date):String).substr(0, expected.length) == expected);
+
+	// a chunked Transfer-Encoding must be used even when Content-Length is present (RFC 7230 §3.3.3),
+	// and the token match must be case-insensitive
+	public function parseBodyPrefersTransferEncoding() {
+		var raw:IdealSource = 'POST / HTTP/1.1\r\nContent-Length: 999\r\nTransfer-Encoding: Chunked\r\n\r\n3\r\n123\r\n0\r\n\r\n';
+		IncomingRequest.parse('127.0.0.1', raw)
+			.next(function(req) return switch req.body {
+				case Plain(source): source.all();
+				case Parsed(_): new Error('unexpected parsed body');
+			})
+			.next(function(chunk) return asserts.assert(chunk.toString() == '123'))
+			.handle(asserts.handle);
+		return asserts;
+	}
 }


### PR DESCRIPTION
`IncomingRequest.parse` framed the request body by Content-Length whenever that header was present, even if a chunked `Transfer-Encoding` was also present. Per RFC 7230 §3.3.3, if a message has `Transfer-Encoding: chunked` the Content-Length must be ignored and the body decoded as chunked.

- When Content-Length is present, still decode the body as chunked if the `Transfer-Encoding` includes `chunked`.
- Match the `chunked` transfer-coding token case-insensitively (both in the Content-Length and no-length branches).

Added a `TestHeader` case asserting that a request with both `Content-Length` and `Transfer-Encoding: Chunked` decodes the chunked body.

Made with [Cursor](https://cursor.com)