### PR TITLE
Treat HEAD requests as having no body when length framing is absent

### DIFF
--- a/src/tink/http/Request.hx
+++ b/src/tink/http/Request.hx
@@ -172,7 +172,7 @@ class IncomingRequest extends Message<IncomingRequestHeader, IncomingRequestBody
               }
             case Failure(_):
               switch [parts.a.method, parts.a.byName(TRANSFER_ENCODING)] {
-                case [GET | OPTIONS, _]: Source.EMPTY;
+                case [GET | HEAD | OPTIONS, _]: Source.EMPTY;
                 case [_, Success((_:String).toLowerCase().split(',').map(StringTools.trim) => encodings)] if(encodings.indexOf('chunked') != -1): Chunked.decode(parts.b);
                 case _: return new Error(411, 'Content-Length header missing');
               }

--- a/tests/TestHeader.hx
+++ b/tests/TestHeader.hx
@@ -193,4 +193,17 @@ class TestHeader {
 			.handle(asserts.handle);
 		return asserts;
 	}
+
+	// HEAD requests typically carry no body, so a missing Content-Length must not fail with 411
+	public function parseHeadRequestHasNoBody() {
+		var raw:IdealSource = 'HEAD / HTTP/1.1\r\nHost: example.com\r\n\r\n';
+		IncomingRequest.parse('127.0.0.1', raw)
+			.next(function(req) return switch req.body {
+				case Plain(source): source.all();
+				case Parsed(_): new Error('unexpected parsed body');
+			})
+			.next(function(chunk) return asserts.assert(chunk.toString() == ''))
+			.handle(asserts.handle);
+		return asserts;
+	}
 }


### PR DESCRIPTION
When a request has neither Content-Length nor Transfer-Encoding, `IncomingRequest.parse` returned an empty body only for `GET` and `OPTIONS` and responded with `411 Length Required` for everything else. `HEAD` requests also normally carry no body, so they were incorrectly rejected.

Adds `HEAD` to the set of methods that yield an empty body when no length framing is present. Other methods still get 411 as before. (`TRACE` is intentionally not added since it is not part of the `Method` enum.)

Added a `TestHeader` case asserting a bare `HEAD` request parses to an empty body instead of failing.

Made with [Cursor](https://cursor.com)