### PR TITLE
Frame SocketClient response body correctly

### DIFF
--- a/src/tink/http/clients/SocketClient.hx
+++ b/src/tink/http/clients/SocketClient.hx
@@ -68,10 +68,16 @@ class SocketClient implements ClientObject {
                 case AllWritten:
                   source.parse(ResponseHeader.parser()).handle(function(o) switch o {
                     case Success(parsed): 
-                      switch parsed.a.getContentLength() {
-                        case Success(len): cb(Success(new IncomingResponse(parsed.a, parsed.b.limit(len))));
-                        case Failure(_): cb(Success(new IncomingResponse(parsed.a, Chunked.decode(parsed.b))));
+                      var body = switch parsed.a.byName(TRANSFER_ENCODING) {
+                        case Success((_:String).toLowerCase().split(',').map(StringTools.trim) => encodings) if(encodings.indexOf('chunked') != -1):
+                          Chunked.decode(parsed.b);
+                        case _:
+                          switch parsed.a.getContentLength() {
+                            case Success(len): parsed.b.limit(len);
+                            case Failure(_): parsed.b; // no framing info: read until the connection closes
+                          }
                       }
+                      cb(Success(new IncomingResponse(parsed.a, body)));
                     case Failure(e): cb(Failure(e));
                   });
                   


### PR DESCRIPTION
`SocketClient` framed the response body by Content-Length and, whenever Content-Length was absent, unconditionally ran the body through `Chunked.decode`. That corrupts responses that are neither chunked nor length-delimited (HTTP/1.1 allows the body to be delimited by connection close).

Framing now follows RFC 7230 §3.3.3 order:
1. `Transfer-Encoding` contains `chunked` (case-insensitive) → `Chunked.decode`
2. otherwise `Content-Length` present → limit to that length
3. otherwise → read the remaining source until the connection closes

Made with [Cursor](https://cursor.com)