### PR TITLE
Frame FlashSocketClient response body when Content-Length is absent

### DIFF
--- a/src/tink/http/clients/FlashSocketClient.hx
+++ b/src/tink/http/clients/FlashSocketClient.hx
@@ -76,10 +76,16 @@ class FlashSocketClient implements ClientObject {
       
       source.parse(ResponseHeader.parser()).handle(function(o) switch o {
         case Success(parsed):
-          switch parsed.a.getContentLength() {
-            case Success(len): cb(Success(new IncomingResponse(parsed.a, parsed.b.limit(len))));
-            case Failure(e): cb(Failure(e));
+          var body = switch parsed.a.byName(TRANSFER_ENCODING) {
+            case Success((_:String).toLowerCase().split(',').map(StringTools.trim) => encodings) if(encodings.indexOf('chunked') != -1):
+              Chunked.decode(parsed.b);
+            case _:
+              switch parsed.a.getContentLength() {
+                case Success(len): parsed.b.limit(len);
+                case Failure(_): parsed.b; // no framing info: read until the connection closes
+              }
           }
+          cb(Success(new IncomingResponse(parsed.a, body)));
         case Failure(e): cb(Failure(e));
       });
       


### PR DESCRIPTION
`FlashSocketClient` only handled responses that carried a `Content-Length`; any response without one failed with the `UnprocessableEntity` error from `getContentLength()`, even though the body may be chunked or delimited by connection close.

Framing now matches `SocketClient`/`TcpClient`: chunked `Transfer-Encoding` (case-insensitive) → `Chunked.decode`, else `Content-Length` → limit, else read the remaining source until the connection closes.

Made with [Cursor](https://cursor.com)