### PR TITLE
Include non-default port in auto-injected Host header (SocketClient)

### DIFF
--- a/src/tink/http/clients/SocketClient.hx
+++ b/src/tink/http/clients/SocketClient.hx
@@ -40,7 +40,14 @@ class SocketClient implements ClientObject {
           
           switch req.header.byName('host') {
             case Success(_): // ok
-            case Failure(_): addHeaders([new HeaderField('host', req.header.url.host.name)]);
+            case Failure(_):
+              var defaultPort = req.header.url.scheme == 'https' ? 443 : 80;
+              var host = switch req.header.url.host.port {
+                case null: req.header.url.host.name;
+                case p if(p == defaultPort): req.header.url.host.name;
+                case p: '${req.header.url.host.name}:$p';
+              }
+              addHeaders([new HeaderField('host', host)]);
           }
           
           var hostname = req.header.url.host.name;


### PR DESCRIPTION
When `SocketClient` auto-injects a `Host` header it used only the hostname, dropping any non-default port. A request to e.g. `http://example.com:8080/` would send `Host: example.com`, which is incorrect per RFC 7230 §5.4.

The injected `Host` value now includes the port when it is present and non-default for the scheme (i.e. not 80 for http / 443 for https), e.g. `Host: example.com:8080`.

Made with [Cursor](https://cursor.com)