### PR TITLE
Auto-inject Host in FlashSocketClient; enforce Connection: close in TcpClient

### DIFF
--- a/src/tink/http/clients/FlashSocketClient.hx
+++ b/src/tink/http/clients/FlashSocketClient.hx
@@ -37,15 +37,33 @@ class FlashSocketClient implements ClientObject {
   public function request(req:OutgoingRequest):Promise<IncomingResponse> {
     return Future.irreversible(function(cb) {
       
+      function addHeaders(headers:Array<HeaderField>)
+        req = new OutgoingRequest(req.header.concat(headers), req.body);
+      
       switch req.header.byName('connection') {
-        case Success((_:String).toLowerCase() => 'close'): // ok
+        case Success((_:String).toLowerCase() => 'close'):
+          // ok
         case Success(v):
           cb(Failure(new Error('Only "Connection: Close" is supported. But specified as "$v"')));
           return;
-        case Failure(_): @:privateAccess req.header.fields.push(new HeaderField('connection', 'close'));
+        case Failure(_):
+          addHeaders([new HeaderField('connection', 'close')]);
       }
       
-      var socket = getSocket(req.header.url.scheme == 'https');
+      switch req.header.byName('host') {
+        case Success(_): // ok
+        case Failure(_):
+          var defaultPort = req.header.url.scheme == 'https' ? 443 : 80;
+          var host = switch req.header.url.host.port {
+            case null: req.header.url.host.name;
+            case p if(p == defaultPort): req.header.url.host.name;
+            case p: '${req.header.url.host.name}:$p';
+          }
+          addHeaders([new HeaderField('host', host)]);
+      }
+      
+      var secure = req.header.url.scheme == 'https';
+      var socket = getSocket(secure);
       
       var signal = Signal.trigger();
       var source:RealSource = new SignalStream(signal);

--- a/src/tink/http/clients/TcpClient.hx
+++ b/src/tink/http/clients/TcpClient.hx
@@ -17,6 +17,20 @@ class TcpClient implements ClientObject {
       switch Helpers.checkScheme(req.header.url) {
         case Some(e): cb(Failure(e));
         case None:
+          
+          function addHeaders(headers:Array<HeaderField>)
+            req = new OutgoingRequest(req.header.concat(headers), req.body);
+          
+          switch req.header.byName('connection') {
+            case Success((_:String).toLowerCase() => 'close'):
+              // ok
+            case Success(v):
+              cb(Failure(new Error('Only "Connection: Close" is supported. But specified as "$v"')));
+              return;
+            case Failure(_):
+              addHeaders([new HeaderField('connection', 'close')]);
+          }
+          
           switch req.header.byName('host') {
             case Success(_): // ok
             case Failure(_):
@@ -27,7 +41,7 @@ class TcpClient implements ClientObject {
                 case p if(p == defaultPort): url.host.name;
                 case p: '${url.host.name}:$p';
               }
-              req = new OutgoingRequest(req.header.concat([new HeaderField('host', host)]), req.body);
+              addHeaders([new HeaderField('host', host)]);
           }
 
           var cnx = Connection.establish({


### PR DESCRIPTION
## Summary
- `FlashSocketClient`: auto-inject `Host` when missing (omit default 80/443 port, else `hostname:port`), matching `SocketClient`/`TcpClient`
- `TcpClient`: until connection reuse exists, match `SocketClient` `Connection` handling — add `connection: close` if absent; reject non-close values

## Test plan
- [ ] Review Host injection logic in `FlashSocketClient` against `SocketClient` (default ports omitted, non-default included)
- [ ] Review `TcpClient` Connection handling matches `SocketClient` (inject close / reject keep-alive etc.)
- [ ] Manual/sys tests if available for TcpClient request headers


Made with [Cursor](https://cursor.com)