### PR TITLE
Frame response bodies for HEAD and no-body statuses

### DIFF
--- a/src/tink/http/clients/FlashSocketClient.hx
+++ b/src/tink/http/clients/FlashSocketClient.hx
@@ -76,16 +76,7 @@ class FlashSocketClient implements ClientObject {
       
       source.parse(ResponseHeader.parser()).handle(function(o) switch o {
         case Success(parsed):
-          var body = switch parsed.a.byName(TRANSFER_ENCODING) {
-            case Success((_:String).toLowerCase().split(',').map(StringTools.trim) => encodings) if(encodings.indexOf('chunked') != -1):
-              Chunked.decode(parsed.b);
-            case _:
-              switch parsed.a.getContentLength() {
-                case Success(len): parsed.b.limit(len);
-                case Failure(_): parsed.b; // no framing info: read until the connection closes
-              }
-          }
-          cb(Success(new IncomingResponse(parsed.a, body)));
+          cb(Success(new IncomingResponse(parsed.a, Helpers.frameResponseBody(req.header.method, parsed.a, parsed.b))));
         case Failure(e): cb(Failure(e));
       });
       

--- a/src/tink/http/clients/Helpers.hx
+++ b/src/tink/http/clients/Helpers.hx
@@ -1,7 +1,12 @@
 package tink.http.clients;
 
 import tink.Url;
+import tink.http.Chunked;
+import tink.http.Header;
+import tink.http.Method;
+import tink.http.Response;
 
+using tink.io.Source;
 using tink.CoreApi;
 
 class Helpers {
@@ -17,5 +22,33 @@ class Helpers {
 	}
 	public static inline function invalidSchemeError(url:Url) {
 		return new Error(BadRequest, 'Invalid Scheme "${url.scheme}" (expected http/https) in URL: ${url.toString()}');
+	}
+
+	/**
+	 * Frame a raw HTTP/1.1 response body per RFC 9112 §6.3.
+	 *
+	 * 1. HEAD → empty body (ignore Content-Length / Transfer-Encoding for body bytes)
+	 * 2. 1xx, 204, 304 → empty body
+	 * 3. Transfer-Encoding contains `chunked` → Chunked.decode
+	 * 4. Content-Length present → limit(len)
+	 * 5. else → read until connection closes
+	 */
+	public static function frameResponseBody(method:Method, header:ResponseHeader, body:RealSource):RealSource {
+		if(method == HEAD)
+			return Source.EMPTY;
+
+		final code = header.statusCode.toInt();
+		if((code >= 100 && code <= 199) || code == 204 || code == 304)
+			return Source.EMPTY;
+
+		return switch header.byName(TRANSFER_ENCODING) {
+			case Success((_:String).toLowerCase().split(',').map(StringTools.trim) => encodings) if(encodings.indexOf('chunked') != -1):
+				Chunked.decode(body);
+			case _:
+				switch header.getContentLength() {
+					case Success(len): body.limit(len);
+					case Failure(_): body; // no framing info: read until the connection closes
+				}
+		}
 	}
 }

--- a/src/tink/http/clients/SocketClient.hx
+++ b/src/tink/http/clients/SocketClient.hx
@@ -74,17 +74,8 @@ class SocketClient implements ClientObject {
               switch r {
                 case AllWritten:
                   source.parse(ResponseHeader.parser()).handle(function(o) switch o {
-                    case Success(parsed): 
-                      var body = switch parsed.a.byName(TRANSFER_ENCODING) {
-                        case Success((_:String).toLowerCase().split(',').map(StringTools.trim) => encodings) if(encodings.indexOf('chunked') != -1):
-                          Chunked.decode(parsed.b);
-                        case _:
-                          switch parsed.a.getContentLength() {
-                            case Success(len): parsed.b.limit(len);
-                            case Failure(_): parsed.b; // no framing info: read until the connection closes
-                          }
-                      }
-                      cb(Success(new IncomingResponse(parsed.a, body)));
+                    case Success(parsed):
+                      cb(Success(new IncomingResponse(parsed.a, Helpers.frameResponseBody(req.header.method, parsed.a, parsed.b))));
                     case Failure(e): cb(Failure(e));
                   });
                   

--- a/src/tink/http/clients/TcpClient.hx
+++ b/src/tink/http/clients/TcpClient.hx
@@ -43,18 +43,9 @@ class TcpClient implements ClientObject {
           });
           
           cnx.source.parse(ResponseHeader.parser())
-            .next(function(parsed) {
-              var body = switch parsed.a.byName(TRANSFER_ENCODING) {
-                case Success((_:String).toLowerCase().split(',').map(StringTools.trim) => encodings) if(encodings.indexOf('chunked') != -1):
-                  Chunked.decode(parsed.b);
-                case _:
-                  switch parsed.a.getContentLength() {
-                    case Success(len): parsed.b.limit(len);
-                    case Failure(_): parsed.b; // no framing info: read until the connection closes
-                  }
-              }
-              return new IncomingResponse(parsed.a, body);
-            })
+            .next(function(parsed)
+              return new IncomingResponse(parsed.a, Helpers.frameResponseBody(req.header.method, parsed.a, parsed.b))
+            )
             .handle(cb);
       }
     });

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -17,6 +17,7 @@ class RunTests {
     new TestHeader(),
       new Sses(),
       new TestChunked(),
+      new TestResponseFraming(),
       new FetchTest(#if php Php #end),
     #end
     ]);

--- a/tests/TestResponseFraming.hx
+++ b/tests/TestResponseFraming.hx
@@ -1,0 +1,90 @@
+package;
+
+import tink.http.*;
+import tink.http.Response;
+import tink.http.Header;
+import tink.http.clients.Helpers;
+
+using tink.io.Source;
+using tink.CoreApi;
+
+@:asserts
+class TestResponseFraming {
+	public function new() {}
+
+	// HEAD must yield an empty body even when Content-Length claims otherwise (RFC 9112 §6.3)
+	public function headIgnoresContentLength() {
+		var header = new ResponseHeader(OK, OK, [new HeaderField('Content-Length', '5')]);
+		var source:RealSource = 'helloEXTRA';
+		Helpers.frameResponseBody(HEAD, header, source).all()
+			.next(chunk -> asserts.assert(chunk.toString() == ''))
+			.handle(asserts.handle);
+		return asserts;
+	}
+
+	// HEAD must not attempt chunked decoding
+	public function headIgnoresTransferEncoding() {
+		var header = new ResponseHeader(OK, OK, [new HeaderField(TRANSFER_ENCODING, 'chunked')]);
+		var source:RealSource = '5\r\nhello\r\n0\r\n\r\n';
+		Helpers.frameResponseBody(HEAD, header, source).all()
+			.next(chunk -> asserts.assert(chunk.toString() == ''))
+			.handle(asserts.handle);
+		return asserts;
+	}
+
+	@:variant(204)
+	@:variant(304)
+	@:variant(100)
+	@:variant(101)
+	public function noBodyStatuses(code:Int) {
+		var header = new ResponseHeader(code, code, [new HeaderField('Content-Length', '5')]);
+		var source:RealSource = 'helloEXTRA';
+		Helpers.frameResponseBody(GET, header, source).all()
+			.next(chunk -> asserts.assert(chunk.toString() == ''))
+			.handle(asserts.handle);
+		return asserts;
+	}
+
+	public function contentLengthLimitsBody() {
+		var header = new ResponseHeader(OK, OK, [new HeaderField('Content-Length', '5')]);
+		var source:RealSource = 'helloEXTRA';
+		Helpers.frameResponseBody(GET, header, source).all()
+			.next(chunk -> asserts.assert(chunk.toString() == 'hello'))
+			.handle(asserts.handle);
+		return asserts;
+	}
+
+	// chunked Transfer-Encoding takes precedence; match is case-insensitive
+	public function prefersChunkedTransferEncoding() {
+		var header = new ResponseHeader(OK, OK, [
+			new HeaderField('Content-Length', '999'),
+			new HeaderField(TRANSFER_ENCODING, 'Chunked'),
+		]);
+		var source:RealSource = '5\r\nhello\r\n0\r\n\r\n';
+		Helpers.frameResponseBody(GET, header, source).all()
+			.next(chunk -> asserts.assert(chunk.toString() == 'hello'))
+			.handle(asserts.handle);
+		return asserts;
+	}
+
+	public function chunkedInCommaSeparatedList() {
+		var header = new ResponseHeader(OK, OK, [
+			new HeaderField(TRANSFER_ENCODING, 'gzip, chunked'),
+		]);
+		var source:RealSource = '5\r\nhello\r\n0\r\n\r\n';
+		Helpers.frameResponseBody(GET, header, source).all()
+			.next(chunk -> asserts.assert(chunk.toString() == 'hello'))
+			.handle(asserts.handle);
+		return asserts;
+	}
+
+	// without CL or TE, the remainder of the source is the body (connection close)
+	public function readsUntilClose() {
+		var header = new ResponseHeader(OK, OK, []);
+		var source:RealSource = 'until-close';
+		Helpers.frameResponseBody(GET, header, source).all()
+			.next(chunk -> asserts.assert(chunk.toString() == 'until-close'))
+			.handle(asserts.handle);
+		return asserts;
+	}
+}


### PR DESCRIPTION
## Summary
- Add shared `Helpers.frameResponseBody` implementing RFC 9112 §6.3 for raw HTTP clients (`TcpClient`, `SocketClient`, `FlashSocketClient`)
- Treat HEAD and 1xx/204/304 as empty bodies before applying Transfer-Encoding / Content-Length / connection-close framing
- Add `TestResponseFraming` unit tests for HEAD, no-body statuses, chunked precedence, Content-Length, and close-delimited bodies

## Test plan
- [x] `TestResponseFraming` passes under JS (`-D no_client`)
- [ ] Spot-check a HEAD request via SocketClient/TcpClient against a server that returns Content-Length (should not hang)
- [ ] Spot-check 204/304 responses similarly

Made with [Cursor](https://cursor.com)