### PR TITLE
Reject HTTP/1.1 requests without Host header

### DIFF
--- a/src/tink/http/Request.hx
+++ b/src/tink/http/Request.hx
@@ -158,26 +158,32 @@ class IncomingRequest extends Message<IncomingRequestHeader, IncomingRequestBody
   static public function parse(clientIp, source:RealSource)
     return
       source.parse(IncomingRequestHeader.parser())
-        .next(function (parts):Promise<IncomingRequest> return new IncomingRequest(
-          clientIp,
-          parts.a,
-          Plain(switch parts.a.getContentLength() {
-            case Success(len):
-              // RFC 7230 §3.3.3: a chunked Transfer-Encoding takes precedence over Content-Length
-              switch parts.a.byName(TRANSFER_ENCODING) {
-                case Success((_:String).toLowerCase().split(',').map(StringTools.trim) => encodings) if(encodings.indexOf('chunked') != -1):
-                  Chunked.decode(parts.b);
-                case _:
-                  parts.b.limit(len);
-              }
-            case Failure(_):
-              switch [parts.a.method, parts.a.byName(TRANSFER_ENCODING)] {
-                case [GET | HEAD | OPTIONS, _]: Source.EMPTY;
-                case [_, Success((_:String).toLowerCase().split(',').map(StringTools.trim) => encodings)] if(encodings.indexOf('chunked') != -1): Chunked.decode(parts.b);
-                case _: return new Error(411, 'Content-Length header missing');
-              }
-          })
-        ));
+        .next(function (parts):Promise<IncomingRequest> {
+          // RFC 9112 §3.2.2 / RFC 7230 §5.4: HTTP/1.1 requests must include a Host header
+          if (parts.a.protocol == HTTP1_1 && parts.a.get(HOST).length == 0)
+            return new Error(400, 'Host header missing');
+
+          return new IncomingRequest(
+            clientIp,
+            parts.a,
+            Plain(switch parts.a.getContentLength() {
+              case Success(len):
+                // RFC 7230 §3.3.3: a chunked Transfer-Encoding takes precedence over Content-Length
+                switch parts.a.byName(TRANSFER_ENCODING) {
+                  case Success((_:String).toLowerCase().split(',').map(StringTools.trim) => encodings) if(encodings.indexOf('chunked') != -1):
+                    Chunked.decode(parts.b);
+                  case _:
+                    parts.b.limit(len);
+                }
+              case Failure(_):
+                switch [parts.a.method, parts.a.byName(TRANSFER_ENCODING)] {
+                  case [GET | HEAD | OPTIONS, _]: Source.EMPTY;
+                  case [_, Success((_:String).toLowerCase().split(',').map(StringTools.trim) => encodings)] if(encodings.indexOf('chunked') != -1): Chunked.decode(parts.b);
+                  case _: return new Error(411, 'Content-Length header missing');
+                }
+            })
+          );
+        });
 }
 
 enum IncomingRequestBody {

--- a/tests/TestHeader.hx
+++ b/tests/TestHeader.hx
@@ -183,7 +183,7 @@ class TestHeader {
 	// a chunked Transfer-Encoding must be used even when Content-Length is present (RFC 7230 §3.3.3),
 	// and the token match must be case-insensitive
 	public function parseBodyPrefersTransferEncoding() {
-		var raw:IdealSource = 'POST / HTTP/1.1\r\nContent-Length: 999\r\nTransfer-Encoding: Chunked\r\n\r\n3\r\n123\r\n0\r\n\r\n';
+		var raw:IdealSource = 'POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 999\r\nTransfer-Encoding: Chunked\r\n\r\n3\r\n123\r\n0\r\n\r\n';
 		IncomingRequest.parse('127.0.0.1', raw)
 			.next(function(req) return switch req.body {
 				case Plain(source): source.all();
@@ -203,6 +203,45 @@ class TestHeader {
 				case Parsed(_): new Error('unexpected parsed body');
 			})
 			.next(function(chunk) return asserts.assert(chunk.toString() == ''))
+			.handle(asserts.handle);
+		return asserts;
+	}
+
+	// RFC 9112 §3.2.2: HTTP/1.1 requests without a Host header must be rejected
+	public function parseHttp11MissingHost() {
+		var raw:IdealSource = 'GET / HTTP/1.1\r\n\r\n';
+		IncomingRequest.parse('127.0.0.1', raw)
+			.handle(function(o) switch o {
+				case Success(_):
+					asserts.fail('expected Host rejection');
+				case Failure(e):
+					asserts.assert(e.code == 400);
+					asserts.assert(e.message == 'Host header missing');
+					asserts.done();
+			});
+		return asserts;
+	}
+
+	public function parseHttp11WithHost() {
+		var raw:IdealSource = 'GET / HTTP/1.1\r\nHost: example.com\r\n\r\n';
+		IncomingRequest.parse('127.0.0.1', raw)
+			.next(function(req) {
+				asserts.assert(req.header.byName(HOST).sure() == 'example.com');
+				return Noise;
+			})
+			.handle(asserts.handle);
+		return asserts;
+	}
+
+	// HTTP/1.0 does not require Host
+	public function parseHttp10MissingHost() {
+		var raw:IdealSource = 'GET / HTTP/1.0\r\n\r\n';
+		IncomingRequest.parse('127.0.0.1', raw)
+			.next(function(req) {
+				asserts.assert(req.header.protocol == HTTP1_0);
+				asserts.assert(req.header.get(HOST).length == 0);
+				return Noise;
+			})
 			.handle(asserts.handle);
 		return asserts;
 	}


### PR DESCRIPTION
## Summary
- `IncomingRequest.parse` now returns `400 Bad Request` when an HTTP/1.1 request lacks a `Host` header (RFC 9112 §3.2.2 / RFC 7230 §5.4), so TcpContainer and other parse-based servers benefit automatically.
- HTTP/1.0 requests without `Host` remain accepted.
- Adds regression tests for HTTP/1.1 missing, HTTP/1.1 present, and HTTP/1.0 missing.

## Test plan
- [x] `parseHttp11MissingHost` asserts 400 / `Host header missing`
- [x] `parseHttp11WithHost` accepts a present Host
- [x] `parseHttp10MissingHost` accepts HTTP/1.0 without Host
- [x] Existing `parseBodyPrefersTransferEncoding` / `parseHeadRequestHasNoBody` still pass (Host added where needed)
- [ ] CI green

Made with [Cursor](https://cursor.com)