### PR TITLE
Deduplicate socket client header defaults via Helpers

### DIFF
--- a/src/tink/http/clients/FlashSocketClient.hx
+++ b/src/tink/http/clients/FlashSocketClient.hx
@@ -4,7 +4,6 @@ import haxe.io.Bytes;
 import tink.http.Client;
 import tink.http.Response;
 import tink.http.Request;
-import tink.http.Header;
 import tink.io.Sink;
 import tink.io.Worker;
 import tink.streams.Stream;
@@ -36,30 +35,12 @@ class FlashSocketClient implements ClientObject {
   
   public function request(req:OutgoingRequest):Promise<IncomingResponse> {
     return Future.irreversible(function(cb) {
-      
-      function addHeaders(headers:Array<HeaderField>)
-        req = new OutgoingRequest(req.header.concat(headers), req.body);
-      
-      switch req.header.byName('connection') {
-        case Success((_:String).toLowerCase() => 'close'):
-          // ok
-        case Success(v):
-          cb(Failure(new Error('Only "Connection: Close" is supported. But specified as "$v"')));
+      switch Helpers.addSocketHeaders(req) {
+        case Failure(e):
+          cb(Failure(e));
           return;
-        case Failure(_):
-          addHeaders([new HeaderField('connection', 'close')]);
-      }
-      
-      switch req.header.byName('host') {
-        case Success(_): // ok
-        case Failure(_):
-          var defaultPort = req.header.url.scheme == 'https' ? 443 : 80;
-          var host = switch req.header.url.host.port {
-            case null: req.header.url.host.name;
-            case p if(p == defaultPort): req.header.url.host.name;
-            case p: '${req.header.url.host.name}:$p';
-          }
-          addHeaders([new HeaderField('host', host)]);
+        case Success(v):
+          req = v;
       }
       
       var secure = req.header.url.scheme == 'https';

--- a/src/tink/http/clients/Helpers.hx
+++ b/src/tink/http/clients/Helpers.hx
@@ -4,6 +4,7 @@ import tink.Url;
 import tink.http.Chunked;
 import tink.http.Header;
 import tink.http.Method;
+import tink.http.Request;
 import tink.http.Response;
 
 using tink.io.Source;
@@ -22,6 +23,39 @@ class Helpers {
 	}
 	public static inline function invalidSchemeError(url:Url) {
 		return new Error(BadRequest, 'Invalid Scheme "${url.scheme}" (expected http/https) in URL: ${url.toString()}');
+	}
+
+	/**
+	 * For socket clients that do not reuse connections yet:
+	 * ensure `Connection: close` and inject `Host` when missing.
+	 */
+	public static function addSocketHeaders(req:OutgoingRequest):Outcome<OutgoingRequest, Error> {
+		function addHeaders(headers:Array<HeaderField>)
+			req = new OutgoingRequest(req.header.concat(headers), req.body);
+
+		switch req.header.byName('connection') {
+			case Success((_:String).toLowerCase() => 'close'):
+				// ok
+			case Success(v):
+				return Failure(new Error('Only "Connection: Close" is supported. But specified as "$v"'));
+			case Failure(_):
+				addHeaders([new HeaderField('connection', 'close')]);
+		}
+
+		switch req.header.byName('host') {
+			case Success(_): // ok
+			case Failure(_):
+				final url = req.header.url;
+				final defaultPort = url.scheme == 'https' ? 443 : 80;
+				final host = switch url.host.port {
+					case null: url.host.name;
+					case p if(p == defaultPort): url.host.name;
+					case p: '${url.host.name}:$p';
+				}
+				addHeaders([new HeaderField('host', host)]);
+		}
+
+		return Success(req);
 	}
 
 	/**

--- a/src/tink/http/clients/SocketClient.hx
+++ b/src/tink/http/clients/SocketClient.hx
@@ -3,7 +3,6 @@ package tink.http.clients;
 import tink.http.Client;
 import tink.http.Response;
 import tink.http.Request;
-import tink.http.Header;
 import tink.io.Sink;
 import tink.io.Worker;
 
@@ -24,30 +23,12 @@ class SocketClient implements ClientObject {
         case Some(e):
           cb(Failure(e));
         case None:
-          
-          function addHeaders(headers:Array<HeaderField>)
-            req = new OutgoingRequest(req.header.concat(headers), req.body);
-          
-          switch req.header.byName('connection') {
-            case Success((_:String).toLowerCase() => 'close'):
-              // ok
-            case Success(v):
-              cb(Failure(new Error('Only "Connection: Close" is supported. But specified as "$v"')));
+          switch Helpers.addSocketHeaders(req) {
+            case Failure(e):
+              cb(Failure(e));
               return;
-            case Failure(_):
-              addHeaders([new HeaderField('connection', 'close')]);
-          }
-          
-          switch req.header.byName('host') {
-            case Success(_): // ok
-            case Failure(_):
-              var defaultPort = req.header.url.scheme == 'https' ? 443 : 80;
-              var host = switch req.header.url.host.port {
-                case null: req.header.url.host.name;
-                case p if(p == defaultPort): req.header.url.host.name;
-                case p: '${req.header.url.host.name}:$p';
-              }
-              addHeaders([new HeaderField('host', host)]);
+            case Success(v):
+              req = v;
           }
           
           var hostname = req.header.url.host.name;

--- a/src/tink/http/clients/TcpClient.hx
+++ b/src/tink/http/clients/TcpClient.hx
@@ -1,7 +1,6 @@
 package tink.http.clients;
 
 import tink.http.Client;
-import tink.http.Header;
 import tink.http.Response;
 import tink.http.Request;
 import tink.tcp.*;
@@ -17,31 +16,12 @@ class TcpClient implements ClientObject {
       switch Helpers.checkScheme(req.header.url) {
         case Some(e): cb(Failure(e));
         case None:
-          
-          function addHeaders(headers:Array<HeaderField>)
-            req = new OutgoingRequest(req.header.concat(headers), req.body);
-          
-          switch req.header.byName('connection') {
-            case Success((_:String).toLowerCase() => 'close'):
-              // ok
-            case Success(v):
-              cb(Failure(new Error('Only "Connection: Close" is supported. But specified as "$v"')));
+          switch Helpers.addSocketHeaders(req) {
+            case Failure(e):
+              cb(Failure(e));
               return;
-            case Failure(_):
-              addHeaders([new HeaderField('connection', 'close')]);
-          }
-          
-          switch req.header.byName('host') {
-            case Success(_): // ok
-            case Failure(_):
-              var url = req.header.url;
-              var defaultPort = url.scheme == 'https' ? 443 : 80;
-              var host = switch url.host.port {
-                case null: url.host.name;
-                case p if(p == defaultPort): url.host.name;
-                case p: '${url.host.name}:$p';
-              }
-              addHeaders([new HeaderField('host', host)]);
+            case Success(v):
+              req = v;
           }
 
           var cnx = Connection.establish({


### PR DESCRIPTION
## Summary
- Move the shared `addHeaders` / Connection: close / Host injection logic from `SocketClient`, `TcpClient`, and `FlashSocketClient` into `Helpers.addSocketHeaders`
- Keep behavior unchanged; clients now call the helper and proceed with the updated request

## Test plan
- [ ] Confirm existing socket/tcp client tests still pass
- [ ] Spot-check that missing Host is still injected with non-default ports
- [ ] Spot-check that non-`close` Connection values are still rejected


Made with [Cursor](https://cursor.com)